### PR TITLE
Fix from address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ SANDBOX
 vendor
 perf.data*
 flamegraph*.svg
+Cargo.lock

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -59,8 +59,8 @@ impl std::ops::Deref for UdxSocket {
 }
 
 impl UdxSocket {
-    pub async fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
-        let inner = UdxSocketInner::bind(addr).await?;
+    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+        let inner = UdxSocketInner::bind(addr)?;
         let socket = Self(Arc::new(Mutex::new(inner)));
         let driver = SocketDriver(socket.clone());
         tokio::spawn(async {
@@ -236,7 +236,7 @@ impl SocketStats {
 }
 
 impl UdxSocketInner {
-    pub async fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
         let socket = std::net::UdpSocket::bind(addr)?;
         let socket = UdpSocket::from_std(socket)?;
         let (send_tx, send_rx) = mpsc::unbounded_channel();

--- a/udx-udp/src/unix.rs
+++ b/udx-udp/src/unix.rs
@@ -1,8 +1,7 @@
 use std::{
-    io,
-    io::IoSliceMut,
+    io::{self, IoSliceMut},
     mem::{self, MaybeUninit},
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     os::unix::io::AsRawFd,
     ptr,
     sync::atomic::AtomicUsize,
@@ -550,8 +549,22 @@ fn decode_recv(
     }
 
     let addr = match libc::c_int::from(name.ss_family) {
-        libc::AF_INET => unsafe { SocketAddr::V4(ptr::read(&name as *const _ as _)) },
-        libc::AF_INET6 => unsafe { SocketAddr::V6(ptr::read(&name as *const _ as _)) },
+        libc::AF_INET => unsafe {
+            // Cast to sockaddr_in first to get correct memory layout
+            let addr: &libc::sockaddr_in = &*(&name as *const _ as *const libc::sockaddr_in);
+            SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::from(u32::from_be(addr.sin_addr.s_addr))),
+                u16::from_be(addr.sin_port),
+            )
+        },
+        libc::AF_INET6 => unsafe {
+            // Cast to sockaddr_in6 first to get correct memory layout
+            let addr: &libc::sockaddr_in6 = &*(&name as *const _ as *const libc::sockaddr_in6);
+            SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::from(addr.sin6_addr.s6_addr)),
+                u16::from_be(addr.sin6_port),
+            )
+        },
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
This fixes a bug where we were getting the ip address of sender wrong. We were directly trying to cast `libc::sockaddr_storage` into a `SocketAddr` but these have different memory layouts so we got something weird.

I also noticed that `UdxSocket::bind` did not need to be `async`, so I fixed that. And added `Cargo.lock` to `.gitignore`.

With this my `hyperswarm-dht` code is now able to check that messages sent with `async-udx` have a valid id.