### PR TITLE
Add half-open stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ SANDBOX
 vendor
 perf.data*
 flamegraph*.svg
+Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-header -->
+
+## [Unreleased] - ReleaseDate
+
+### Added
+
+Added ability to create a "half-open" - preventing messages with the half-open stream id from being routed as socket messages.
+The JavaScript implementation does something similar.
+
+### Changed
+
+`UdxSocket::bind` is no longer async. It didn't need to be, but it does need have a tokio runtime running.
+
+Fixes a bug where we were getting the socket address of sender wrong
+
+### Removed
+
+
+<!-- next-url -->
+[Unreleased]: https://github.com/datrs/async-udx/compare/v0.1.0...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-udx"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Rust port of libudx, a protocol for reliable, multiplex, and congestion controlled streams over udp"
 authors = ["Franz Heinzmann (Frando) <frando@unbiskant.org>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ categories = [
 bitflags = "1.3.2"
 tokio = { version = "1.21.2", features = ["net", "macros", "rt-multi-thread", "time", "io-util", "sync"] }
 futures = "0.3.25"
-derivative = "2.2.0"
 tracing = "0.1.37"
 bytes = "1.2.1"
 log = "0.4.17"

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -6,7 +6,7 @@ use tokio::{
     net::TcpStream,
 };
 
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 criterion_group!(server_benches, bench_throughput);
 criterion_main!(server_benches);
 fn rt() -> tokio::runtime::Runtime {

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -41,8 +41,8 @@ fn bench_throughput(c: &mut Criterion) {
                     let num_streams = n_streams;
                     let limit = *len / num_streams;
                     b.to_async(&rt).iter_custom(|iters| async move {
-                        let socka = UdxSocket::bind("127.0.0.1:0").await.unwrap();
-                        let sockb = UdxSocket::bind("127.0.0.1:0").await.unwrap();
+                        let socka = UdxSocket::bind("127.0.0.1:0").unwrap();
+                        let sockb = UdxSocket::bind("127.0.0.1:0").unwrap();
                         let addra = socka.local_addr().unwrap();
                         let addrb = sockb.local_addr().unwrap();
                         let mut readers = vec![];
@@ -191,8 +191,8 @@ async fn setup_pipe_tcp() -> io::Result<(TcpStream, TcpStream)> {
 }
 
 async fn setup_pipe_udx() -> io::Result<(UdxStream, UdxStream)> {
-    let socka = UdxSocket::bind("127.0.0.1:0").await?;
-    let sockb = UdxSocket::bind("127.0.0.1:0").await?;
+    let socka = UdxSocket::bind("127.0.0.1:0")?;
+    let sockb = UdxSocket::bind("127.0.0.1:0")?;
     let addra = socka.local_addr()?;
     let addrb = sockb.local_addr()?;
     let streama = socka.connect(addrb, 1, 2)?;

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -77,7 +77,7 @@ fn usize_from_env(name: &str, default: usize) -> usize {
     std::env::var(name)
         .map(|x| {
             x.parse::<usize>()
-                .expect(&format!("{} must be a number", name))
+                .unwrap_or_else(|_| panic!("{} must be a number", name))
         })
         .unwrap_or(default)
 }

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -15,8 +15,8 @@ async fn main() {
 }
 
 async fn run(total: usize, num_streams: usize) -> io::Result<()> {
-    let socka = UdxSocket::bind("127.0.0.1:0").await?;
-    let sockb = UdxSocket::bind("127.0.0.1:0").await?;
+    let socka = UdxSocket::bind("127.0.0.1:0")?;
+    let sockb = UdxSocket::bind("127.0.0.1:0")?;
     let addra = socka.local_addr()?;
     let addrb = sockb.local_addr()?;
 

--- a/examples/multi_stream.rs
+++ b/examples/multi_stream.rs
@@ -33,9 +33,9 @@ async fn main() {
         let i = i as u32;
         let streama = socka.connect(addrb, 1000 + i, i).unwrap();
         let streamb = sockb.connect(addra, i, 1000 + i).unwrap();
-        let read_buf = vec![0u8; MSGSIZE as usize];
-        let write_buf = vec![i as u8; MSGSIZE as usize];
-        let (reader, writer) = if i % 2 == 0 {
+        let read_buf = vec![0u8; MSGSIZE];
+        let write_buf = vec![i as u8; MSGSIZE];
+        let (reader, writer) = if i.is_multiple_of(2) {
             (streama, streamb)
         } else {
             (streamb, streama)

--- a/examples/multi_stream.rs
+++ b/examples/multi_stream.rs
@@ -21,8 +21,8 @@ async fn main() {
     );
 
     let host = "127.0.0.1";
-    let socka = UdxSocket::bind(format!("{host}:0")).await.unwrap();
-    let sockb = UdxSocket::bind(format!("{host}:0")).await.unwrap();
+    let socka = UdxSocket::bind(format!("{host}:0")).unwrap();
+    let sockb = UdxSocket::bind(format!("{host}:0")).unwrap();
     let addra = socka.local_addr().unwrap();
     let addrb = sockb.local_addr().unwrap();
     eprintln!("addra {}", addra);

--- a/examples/multi_stream.rs
+++ b/examples/multi_stream.rs
@@ -1,4 +1,4 @@
-use async_udx::{UdxSocket, UDX_DATA_MTU};
+use async_udx::{UDX_DATA_MTU, UdxSocket};
 use std::time::Instant;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 

--- a/examples/rw.rs
+++ b/examples/rw.rs
@@ -4,7 +4,7 @@ use std::{future::Future, io};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::task::JoinHandle;
 
-use async_udx::{UdxSocket, UdxStream, UDX_DATA_MTU};
+use async_udx::{UDX_DATA_MTU, UdxSocket, UdxStream};
 
 pub fn spawn<T>(name: impl ToString, future: T) -> JoinHandle<()>
 where

--- a/examples/rw.rs
+++ b/examples/rw.rs
@@ -34,7 +34,7 @@ async fn main() -> io::Result<()> {
         .next()
         .expect("invalid connect addr");
     eprintln!("{} -> {}", listen_addr, connect_addr);
-    let sock = UdxSocket::bind(listen_addr).await?;
+    let sock = UdxSocket::bind(listen_addr)?;
     let stream = sock.connect(connect_addr, 1, 1)?;
     let max_len = UDX_DATA_MTU * 64;
     let read = spawn("read", read_loop(stream.clone(), max_len));

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -7,10 +7,10 @@ async fn main() -> io::Result<()> {
     tracing_subscriber::fmt::init();
 
     // Bind two sockets
-    let socka = UdxSocket::bind("127.0.0.1:20004").await?;
+    let socka = UdxSocket::bind("127.0.0.1:20004")?;
     let addra = socka.local_addr()?;
     eprintln!("Socket A bound to {addra}");
-    let sockb = UdxSocket::bind("127.0.0.1:20005").await?;
+    let sockb = UdxSocket::bind("127.0.0.1:20005")?;
     let addrb = sockb.local_addr()?;
     eprintln!("Socket B bound to {addrb}");
 

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,7 @@
+pre-release-replacements = [
+  {file="CHANGELOG.md", search="Unreleased", replace="{{version}}"},
+  {file="CHANGELOG.md", search="\\.\\.\\.HEAD", replace="...{{tag_name}}", exactly=1},
+  {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
+  {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate\n\n### Added\n\n### Changed\n\n### Removed\n\n", exactly=1},
+  {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/datrs/async-udx/compare/{{tag_name}}...HEAD", exactly=1},
+]

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -47,7 +47,7 @@ mod tracking {
         /// Acquires the lock for a certain purpose
         ///
         /// The purpose will be recorded in the list of last lock owners
-        pub fn lock(&self, purpose: &'static str) -> MutexGuard<T> {
+        pub fn lock(&self, purpose: &'static str) -> MutexGuard<'_, T> {
             let now = Instant::now();
             let guard = self.inner.lock();
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -146,7 +146,7 @@ mod non_tracking {
         /// Acquires the lock for a certain purpose
         ///
         /// The purpose will be recorded in the list of last lock owners
-        pub fn lock(&self, _purpose: &'static str) -> MutexGuard<T> {
+        pub fn lock(&self, _purpose: &'static str) -> MutexGuard<'_, T> {
             MutexGuard {
                 guard: self.inner.lock(),
             }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,8 +1,8 @@
 use atomic_instant::AtomicInstant;
 use bytes::{BufMut, Bytes};
 use std::fmt::{self, Debug};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{io, net::SocketAddr, sync::atomic::AtomicUsize};
 use udx_udp::Transmit;
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -457,15 +457,15 @@ pub enum SocketEvent {
 // Create an array of IO vectors from a buffer.
 // Safety: buf has to be longer than N. You may only read from slices that have been written to.
 // Taken from: quinn/src/endpoint.rs
-unsafe fn iovectors_from_buf<'a, const N: usize>(buf: &'a mut [u8]) -> [IoSliceMut; N] {
-    let mut iovs = MaybeUninit::<[IoSliceMut<'a>; N]>::uninit();
+unsafe fn iovectors_from_buf<const N: usize>(buf: &mut [u8]) -> [IoSliceMut; N] {
+    let mut iovs = MaybeUninit::<[IoSliceMut; N]>::uninit();
     buf.chunks_mut(buf.len() / N)
         .enumerate()
         .for_each(|(i, buf)| {
             iovs.as_mut_ptr()
                 .cast::<IoSliceMut>()
                 .add(i)
-                .write(IoSliceMut::<'a>::new(buf));
+                .write(IoSliceMut::new(buf));
         });
     iovs.assume_init()
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -135,6 +135,9 @@ impl Future for RecvFuture {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut socket = self.0.lock("UdxSocket::recv");
         if let Some(dgram) = socket.recv_dgrams.pop_front() {
+            if !socket.recv_dgrams.is_empty() {
+                cx.waker().wake_by_ref();
+            }
             Poll::Ready(Ok((dgram.dest, dgram.buf)))
         } else {
             socket.recv_waker = Some(cx.waker().clone());

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -26,7 +26,7 @@ use crate::constants::UDX_MTU;
 use crate::mutex::Mutex;
 use crate::packet::{Dgram, Header, IncomingPacket, PacketSet};
 use crate::stream::UdxStream;
-use crate::udp::{RecvMeta, Transmit, UdpSocket, UdpState, BATCH_SIZE};
+use crate::udp::{BATCH_SIZE, RecvMeta, Transmit, UdpSocket, UdpState};
 
 const MAX_LOOP: usize = 60;
 
@@ -561,10 +561,12 @@ unsafe fn iovectors_from_buf<const N: usize>(buf: &mut [u8]) -> [IoSliceMut<'_>;
     buf.chunks_mut(buf.len() / N)
         .enumerate()
         .for_each(|(i, buf)| {
-            iovs.as_mut_ptr()
-                .cast::<IoSliceMut>()
-                .add(i)
-                .write(IoSliceMut::new(buf));
+            unsafe {
+                iovs.as_mut_ptr()
+                    .cast::<IoSliceMut>()
+                    .add(i)
+                    .write(IoSliceMut::new(buf))
+            };
         });
-    iovs.assume_init()
+    unsafe { iovs.assume_init() }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -471,7 +471,7 @@ pub enum SocketEvent {
 // Create an array of IO vectors from a buffer.
 // Safety: buf has to be longer than N. You may only read from slices that have been written to.
 // Taken from: quinn/src/endpoint.rs
-unsafe fn iovectors_from_buf<const N: usize>(buf: &mut [u8]) -> [IoSliceMut; N] {
+unsafe fn iovectors_from_buf<const N: usize>(buf: &mut [u8]) -> [IoSliceMut<'_>; N] {
     let mut iovs = MaybeUninit::<[IoSliceMut; N]>::uninit();
     buf.chunks_mut(buf.len() / N)
         .enumerate()

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -59,8 +59,8 @@ impl std::ops::Deref for UdxSocket {
 }
 
 impl UdxSocket {
-    pub async fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
-        let inner = UdxSocketInner::bind(addr).await?;
+    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+        let inner = UdxSocketInner::bind(addr)?;
         let socket = Self(Arc::new(Mutex::new(inner)));
         let driver = SocketDriver(socket.clone());
         tokio::spawn(async {
@@ -236,7 +236,7 @@ impl SocketStats {
 }
 
 impl UdxSocketInner {
-    pub async fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
         let socket = std::net::UdpSocket::bind(addr)?;
         let socket = UdpSocket::from_std(socket)?;
         let (send_tx, send_rx) = mpsc::unbounded_channel();

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -452,7 +452,7 @@ impl UdxSocketInner {
         }
     }
 
-    fn poll_recv<'a>(&'a mut self, cx: &mut Context<'_>) -> io::Result<bool> {
+    fn poll_recv(&mut self, cx: &mut Context<'_>) -> io::Result<bool> {
         let mut metas = [RecvMeta::default(); BATCH_SIZE];
         let mut recv_buf = self.recv_buf.take().unwrap();
         let mut iovs = unsafe { iovectors_from_buf::<BATCH_SIZE>(&mut recv_buf) };

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -7,6 +7,8 @@ use std::fmt::Debug;
 use std::io;
 use std::io::IoSliceMut;
 use std::mem::MaybeUninit;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::net::ToSocketAddrs;
 use std::pin::Pin;
@@ -59,6 +61,18 @@ impl std::ops::Deref for UdxSocket {
 }
 
 impl UdxSocket {
+    pub fn bind_rnd() -> io::Result<Self> {
+        Self::bind_port(0)
+    }
+    pub fn bind_port(port: u16) -> io::Result<Self> {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+        Self::bind(addr)
+    }
+    // TODO FIXME this is not async but requires tokio running. Which will cause a runtime failure.
+    // rm this depndence
+    /// Create a socket on the given `addr`. Note `addr` is a *local* address normally it would
+    /// look like `127.0.0.1:8080` which creates a socket on port `8080`. To connect to any random
+    /// port pass `:0` as the port.
     pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
         let inner = UdxSocketInner::bind(addr)?;
         let socket = Self(Arc::new(Mutex::new(inner)));

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -161,7 +161,7 @@ impl UdxStream {
         };
         let stream = UdxStream(Arc::new(Mutex::new(stream)));
         let driver = StreamDriver(stream.clone());
-        tokio::task::spawn(async move { driver.await });
+        tokio::task::spawn(driver);
         stream
     }
 
@@ -575,11 +575,7 @@ impl UdxStreamInner {
                 self.rttvar = rtt / 2;
                 self.rto = self.srtt + UDX_CLOCK_GRANULARITY_MS.max(4 * self.rttvar);
             } else {
-                let delta = if rtt < self.srtt {
-                    self.srtt - rtt
-                } else {
-                    rtt - self.srtt
-                };
+                let delta = self.srtt.abs_diff(rtt);
                 // RTTVAR <- (1 - beta) * RTTVAR + beta * |SRTT - R'| where beta is 1/4
                 self.rttvar = (3 * self.rttvar + delta) / 4;
                 // SRTT <- (1 - alpha) * SRTT + alpha * R' where alpha is 1/8

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -548,9 +548,10 @@ impl UdxStreamInner {
         }
 
         if (self.inflight + UDX_MTU) <= self.cwnd
-            && let Some(waker) = self.write_waker.take() {
-                waker.wake();
-            }
+            && let Some(waker) = self.write_waker.take()
+        {
+            waker.wake();
+        }
 
         // reset rto, since things are moving forward.
         self.rto_timeout
@@ -669,9 +670,10 @@ impl UdxStreamInner {
 
             // packet is next in line, wake the read waker.
             if seq <= self.ack
-                && let Some(waker) = self.read_waker.take() {
-                    waker.wake();
-                }
+                && let Some(waker) = self.read_waker.take()
+            {
+                waker.wake();
+            }
             self.send_state_packet();
         }
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -5,11 +5,9 @@ use std::io;
 async fn socket_dgrams() -> io::Result<()> {
     let socka = UdxSocket::bind("127.0.0.1:0")?;
     let sockb = UdxSocket::bind("127.0.0.1:0")?;
-    let addra = socka.local_addr()?;
-    let addrb = sockb.local_addr()?;
 
     let msg = "hi!".as_bytes();
-    socka.send(addrb, msg);
+    socka.send(sockb.local_addr()?, msg);
     let (_from, buf) = sockb.recv().await?;
     assert_eq!(&buf, msg);
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -3,8 +3,8 @@ use std::io;
 
 #[tokio::test]
 async fn socket_dgrams() -> io::Result<()> {
-    let socka = UdxSocket::bind("127.0.0.1:0").await?;
-    let sockb = UdxSocket::bind("127.0.0.1:0").await?;
+    let socka = UdxSocket::bind("127.0.0.1:0")?;
+    let sockb = UdxSocket::bind("127.0.0.1:0")?;
     let addra = socka.local_addr()?;
     let addrb = sockb.local_addr()?;
 

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -138,16 +138,20 @@ async fn test_halfopen_streams() -> io::Result<()> {
     bstr.write_all(b"BBB").await?;
 
     // b_stream message not seen as socket message to a bc a_stream is half open
-    assert!(tokio::time::timeout(Duration::from_millis(100), a.recv())
-        .await
-        .is_err());
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), a.recv())
+            .await
+            .is_err()
+    );
 
     let mut astr = a_half_str.connect(b.local_addr()?, bid)?;
     bstr.write_all(b"CCC").await?;
     // b_stream message not seen as socket message to a bc a_stream is open
-    assert!(tokio::time::timeout(Duration::from_millis(100), a.recv())
-        .await
-        .is_err());
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), a.recv())
+            .await
+            .is_err()
+    );
     let mut buf = vec![];
     astr.read_buf(&mut buf).await?;
     assert_eq!(&buf, b"AAABBBCCC");

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -80,8 +80,8 @@ async fn stream_close() -> io::Result<()> {
 }
 
 async fn create_pair() -> io::Result<((UdxSocket, UdxSocket), (UdxStream, UdxStream))> {
-    let socka = UdxSocket::bind("127.0.0.1:0").await?;
-    let sockb = UdxSocket::bind("127.0.0.1:0").await?;
+    let socka = UdxSocket::bind("127.0.0.1:0")?;
+    let sockb = UdxSocket::bind("127.0.0.1:0")?;
     let addra = socka.local_addr()?;
     let addrb = sockb.local_addr()?;
     let streama = socka.connect(addrb, 1, 2)?;

--- a/udx-udp/src/unix.rs
+++ b/udx-udp/src/unix.rs
@@ -1,8 +1,7 @@
 use std::{
-    io,
-    io::IoSliceMut,
+    io::{self, IoSliceMut},
     mem::{self, MaybeUninit},
-    net::{IpAddr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     os::unix::io::AsRawFd,
     ptr,
     sync::atomic::AtomicUsize,
@@ -550,8 +549,22 @@ fn decode_recv(
     }
 
     let addr = match libc::c_int::from(name.ss_family) {
-        libc::AF_INET => unsafe { SocketAddr::V4(ptr::read(&name as *const _ as _)) },
-        libc::AF_INET6 => unsafe { SocketAddr::V6(ptr::read(&name as *const _ as _)) },
+        libc::AF_INET => unsafe {
+            // Cast to sockaddr_in first to get correct memory layout
+            let addr: &libc::sockaddr_in = &*(&name as *const _ as *const libc::sockaddr_in);
+            SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::from(u32::from_be(addr.sin_addr.s_addr))),
+                u16::from_be(addr.sin_port),
+            )
+        },
+        libc::AF_INET6 => unsafe {
+            // Cast to sockaddr_in6 first to get correct memory layout
+            let addr: &libc::sockaddr_in6 = &*(&name as *const _ as *const libc::sockaddr_in6);
+            SocketAddr::new(
+                IpAddr::V6(Ipv6Addr::from(addr.sin6_addr.s6_addr)),
+                u16::from_be(addr.sin6_port),
+            )
+        },
         _ => unreachable!(),
     };
 

--- a/udx-udp/src/unix.rs
+++ b/udx-udp/src/unix.rs
@@ -529,7 +529,7 @@ fn decode_recv(
                 // Temporary hack around broken macos ABI. Remove once upstream fixes it.
                 // https://bugreport.apple.com/web/?problemID=48761855
                 if cfg!(target_os = "macos")
-                    && cmsg.cmsg_len as usize == libc::CMSG_LEN(mem::size_of::<u8>() as _) as usize
+                    && cmsg.cmsg_len == libc::CMSG_LEN(mem::size_of::<u8>() as _) as usize
                 {
                     ecn_bits = cmsg::decode::<u8>(cmsg);
                 } else {


### PR DESCRIPTION
(pulled in #5)

This lets us create a "half-open" stream. This is useful because it prevents any stream messages which have the half-open stream's id from being routed as socket messages. The javascript library does something similar.

More concretely, I use this in hyperdht. When I first send a handshake message with the stream id encoded, I create this half-open stream. I can't fully open the stream until I get a reponse which includes the remote stream id. But I may receive udx messages before I can read and process the remote stream id. These messages were causing errors.

Added a CHANGELOG.md and release.toml.
Bumped to edition 2024
Fixed all lints
`cargo fmt` everything